### PR TITLE
Tighten Google Docs ID extraction in GoogleDocsService

### DIFF
--- a/src/inklink/services/google_docs_service.py
+++ b/src/inklink/services/google_docs_service.py
@@ -123,16 +123,17 @@ class GoogleDocsService:
 
         try:
             parsed_url = urlparse(url_or_id)
+            # Only extract ID for official Google Docs URLs at the expected path
             if parsed_url.hostname == "docs.google.com":
-                parts = parsed_url.path.split("/d/")
-                if len(parts) > 1:
-                    doc = parts[1].split("/")
-                    if doc:
-                        return doc[0]
+                # Expect path like '/document/d/<ID>/...'
+                path = parsed_url.path or ""
+                # Split into segments ['', 'document', 'd', '<ID>', ...]
+                segments = path.split("/")
+                if len(segments) >= 4 and segments[1] == "document" and segments[2] == "d" and segments[3]:
+                    return segments[3]
         except Exception:
-            # If parsing fails, assume it's a document ID
+            # If parsing fails or unexpected format, return input as-is
             pass
-          
         return url_or_id
 
     def _process_container(

--- a/tests/test_google_docs_service.py
+++ b/tests/test_google_docs_service.py
@@ -41,6 +41,25 @@ def test_extract_doc_id():
     assert service._extract_doc_id(url) == "ABC12345"
     # ID unchanged
     assert service._extract_doc_id("XYZ") == "XYZ"
+    # Valid URL without trailing segments
+    url_simple = "https://docs.google.com/document/d/DEF67890"
+    assert service._extract_doc_id(url_simple) == "DEF67890"
+
+@pytest.mark.parametrize("url_or_id", [
+    # Hostname not exactly docs.google.com
+    "https://evil.docs.google.com/document/d/ABC12345/edit",
+    "https://docs.google.com.evil.com/document/d/ABC12345/edit",
+    # Missing 'document' segment
+    "https://docs.google.com/d/ABC12345/edit",
+    # Different Google service path
+    "https://docs.google.com/spreadsheets/d/ABC12345/edit",
+    # No scheme
+    "docs.google.com/document/d/ABC12345/edit",
+])
+def test_extract_doc_id_unsafe_hosts_or_paths(url_or_id):
+    service = GoogleDocsService()
+    # Should return the original input when not a canonical Docs URL
+    assert service._extract_doc_id(url_or_id) == url_or_id
 
 
 def test_fetch_success(monkeypatch):


### PR DESCRIPTION
This PR tightens the Google Docs Service doc ID extraction to only match the canonical /document/d/<ID> path. Closes #29.

## Summary by Sourcery

Improve the robustness of Google Docs ID extraction by implementing stricter URL parsing rules

Bug Fixes:
- Tighten the document ID extraction to only match the canonical Google Docs URL format, preventing potential incorrect ID extractions

Tests:
- Add comprehensive test cases to validate the new Google Docs ID extraction logic, including edge cases and unsafe URL formats