### PR TITLE
Fix linting issues in MCP integration files

### DIFF
--- a/src/inklink/mcp/augmented_notebook_tools.py
+++ b/src/inklink/mcp/augmented_notebook_tools.py
@@ -2,7 +2,7 @@
 MCP tools for augmented notebook functionality.
 
 This module integrates the augmented notebook service with Model Context Protocol (MCP)
-tools, enabling Claude and other MCP-compatible interfaces to process reMarkable 
+tools, enabling Claude and other MCP-compatible interfaces to process reMarkable
 notebook pages with AI, knowledge graph integration, and response generation.
 """
 
@@ -19,60 +19,60 @@ logger = logging.getLogger(__name__)
 class AugmentedNotebookMCPIntegration:
     """
     Integration of augmented notebook service with MCP tools.
-    
+
     This class provides MCP-compatible functions for augmented notebook processing,
     allowing Claude to analyze handwritten notes, respond to queries, and add
     results to the knowledge graph.
     """
-    
+
     def __init__(self, augmented_notebook_service: AugmentedNotebookService):
         """
         Initialize the MCP integration.
-        
+
         Args:
             augmented_notebook_service: Service for augmented notebook functionality
         """
         self.augmented_notebook_service = augmented_notebook_service
-    
+
     def process_notebook_page(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """
         Process a notebook page with Claude analysis, knowledge graph integration, and response.
-        
+
         Args:
             params: Dictionary with the following keys:
                 - file_path: Path to the .rm file (required)
                 - append_response: Whether to append the response to the notebook (optional)
                 - extract_knowledge: Whether to extract knowledge to the graph (optional)
                 - categorize_correspondence: Whether to categorize the correspondence (optional)
-                
+
         Returns:
             Result dictionary
         """
         file_path = params.get("file_path")
-        
+
         if not file_path:
             return {"success": False, "error": "file_path is required"}
-        
+
         # Validate that the file exists
         if not os.path.exists(file_path):
             return {"success": False, "error": f"File not found: {file_path}"}
-        
+
         # Get optional parameters
         append_response = params.get("append_response", True)
         extract_knowledge = params.get("extract_knowledge", True)
         categorize_correspondence = params.get("categorize_correspondence", True)
-        
+
         # Process the notebook page
         success, result = self.augmented_notebook_service.process_notebook_page(
             rm_file_path=file_path,
             append_response=append_response,
             extract_knowledge=extract_knowledge,
-            categorize_correspondence=categorize_correspondence
+            categorize_correspondence=categorize_correspondence,
         )
-        
+
         if not success:
             return {"success": False, "error": result.get("error", "Processing failed")}
-        
+
         # Remove large result data to keep MCP response size manageable
         summarized_result = {
             "success": True,
@@ -80,94 +80,115 @@ class AugmentedNotebookMCPIntegration:
             "tags": result.get("tags", []),
             "requests": result.get("requests", []),
             "knowledge_extracted": {
-                "entity_count": len(result.get("knowledge_extracted", {}).get("entities", [])),
-                "relationship_count": len(result.get("knowledge_extracted", {}).get("relationships", [])),
-                "semantic_link_count": len(result.get("knowledge_extracted", {}).get("semantic_links", []))
+                "entity_count": len(
+                    result.get("knowledge_extracted", {}).get("entities", [])
+                ),
+                "relationship_count": len(
+                    result.get("knowledge_extracted", {}).get("relationships", [])
+                ),
+                "semantic_link_count": len(
+                    result.get("knowledge_extracted", {}).get("semantic_links", [])
+                ),
             },
-            "response_generated": bool(result.get("claude_processing", {}).get("response")),
+            "response_generated": bool(
+                result.get("claude_processing", {}).get("response")
+            ),
             "response_appended": bool(result.get("append_results")),
         }
-        
+
         if result.get("append_results"):
-            summarized_result["response_path"] = result["append_results"].get("response_path")
+            summarized_result["response_path"] = result["append_results"].get(
+                "response_path"
+            )
             summarized_result["response_title"] = result["append_results"].get("title")
-        
+
         return summarized_result
-    
+
     def batch_process_notebook_pages(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """
         Process multiple notebook pages in batch.
-        
+
         Args:
             params: Dictionary with the following keys:
                 - file_paths: List of paths to .rm files (required)
                 - append_response: Whether to append responses (optional)
                 - extract_knowledge: Whether to extract knowledge (optional)
                 - categorize_correspondence: Whether to categorize correspondence (optional)
-                
+
         Returns:
             Batch processing results
         """
         file_paths = params.get("file_paths", [])
-        
+
         if not file_paths:
             return {"success": False, "error": "file_paths is required"}
-            
+
         # Get optional parameters
         append_response = params.get("append_response", True)
         extract_knowledge = params.get("extract_knowledge", True)
         categorize_correspondence = params.get("categorize_correspondence", True)
-        
+
         # Process each notebook page
         results = []
         successful = 0
         failed = 0
-        
+
         for file_path in file_paths:
             # Validate that the file exists
             if not os.path.exists(file_path):
-                results.append({
-                    "file_path": file_path,
-                    "success": False,
-                    "error": "File not found"
-                })
+                results.append(
+                    {
+                        "file_path": file_path,
+                        "success": False,
+                        "error": "File not found",
+                    }
+                )
                 failed += 1
                 continue
-            
+
             # Process the notebook page
             success, result = self.augmented_notebook_service.process_notebook_page(
                 rm_file_path=file_path,
                 append_response=append_response,
                 extract_knowledge=extract_knowledge,
-                categorize_correspondence=categorize_correspondence
+                categorize_correspondence=categorize_correspondence,
             )
-            
+
             if success:
                 successful += 1
-                results.append({
-                    "file_path": file_path,
-                    "success": True,
-                    "recognized_text": result.get("recognized_text", "")[:100] + "..." if result.get("recognized_text") else "",
-                    "response_appended": bool(result.get("append_results"))
-                })
+                results.append(
+                    {
+                        "file_path": file_path,
+                        "success": True,
+                        "recognized_text": (
+                            result.get("recognized_text", "")[:100] + "..."
+                            if result.get("recognized_text")
+                            else ""
+                        ),
+                        "response_appended": bool(result.get("append_results")),
+                    }
+                )
             else:
                 failed += 1
-                results.append({
-                    "file_path": file_path,
-                    "success": False,
-                    "error": result.get("error", "Processing failed")
-                })
-        
+                results.append(
+                    {
+                        "file_path": file_path,
+                        "success": False,
+                        "error": result.get("error", "Processing failed"),
+                    }
+                )
+
         return {
             "success": successful > 0,
             "total": len(file_paths),
             "successful": successful,
             "failed": failed,
-            "results": results
+            "results": results,
         }
 
 
 # MCP tool handler functions (for direct use with MCP server)
+
 
 def process_notebook_page(params):
     """MCP handler for processing a notebook page."""

--- a/src/inklink/mcp/knowledge_graph_remarkable_tools.py
+++ b/src/inklink/mcp/knowledge_graph_remarkable_tools.py
@@ -10,7 +10,9 @@ import logging
 import json
 from typing import Dict, Any, List, Optional
 
-from inklink.services.knowledge_graph_integration_service import KnowledgeGraphIntegrationService
+from inklink.services.knowledge_graph_integration_service import (
+    KnowledgeGraphIntegrationService,
+)
 from inklink.di.container import Container
 
 logger = logging.getLogger(__name__)
@@ -19,48 +21,47 @@ logger = logging.getLogger(__name__)
 class KnowledgeGraphRemarkableMCPIntegration:
     """
     Integration of knowledge graph and reMarkable notebook services with MCP tools.
-    
+
     This class provides MCP-compatible functions for knowledge graph and reMarkable
     notebook operations, allowing Claude to extract knowledge from handwritten notes
     and perform semantic search using handwritten queries.
     """
-    
+
     def __init__(self, kg_integration_service: KnowledgeGraphIntegrationService):
         """
         Initialize the MCP integration.
-        
+
         Args:
             kg_integration_service: Service for KG-reMarkable integration
         """
         self.kg_integration_service = kg_integration_service
-    
+
     def extract_knowledge_from_notebook(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """
         Extract knowledge from a reMarkable notebook.
-        
+
         Args:
             params: Dictionary with the following keys:
                 - file_path: Path to the .rm file (required)
                 - entity_types: Optional list of entity types to filter by
-                
+
         Returns:
             Result dictionary
         """
         file_path = params.get("file_path")
         entity_types = params.get("entity_types")
-        
+
         if not file_path:
             return {"success": False, "error": "file_path is required"}
-        
+
         # Extract knowledge from the notebook
         success, result = self.kg_integration_service.extract_knowledge_from_notebook(
-            rm_file_path=file_path,
-            entity_types=entity_types
+            rm_file_path=file_path, entity_types=entity_types
         )
-        
+
         if not success:
             return {"success": False, "error": result.get("error", "Extraction failed")}
-        
+
         return {
             "success": True,
             "recognized_text": result.get("recognized_text"),
@@ -69,20 +70,22 @@ class KnowledgeGraphRemarkableMCPIntegration:
             "semantic_links_count": len(result.get("semantic_links", [])),
             "entities": result.get("created_entities", []),
             "relationships": result.get("created_relationships", []),
-            "semantic_links": result.get("semantic_links", [])
+            "semantic_links": result.get("semantic_links", []),
         }
-    
-    def semantic_search_from_handwritten_query(self, params: Dict[str, Any]) -> Dict[str, Any]:
+
+    def semantic_search_from_handwritten_query(
+        self, params: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """
         Perform semantic search using a handwritten query.
-        
+
         Args:
             params: Dictionary with the following keys:
                 - file_path: Path to the .rm file with handwritten query (required)
                 - min_similarity: Minimum similarity threshold (0-1)
                 - max_results: Maximum number of results to return
                 - entity_types: Optional list of entity types to filter by
-                
+
         Returns:
             Result dictionary
         """
@@ -90,67 +93,76 @@ class KnowledgeGraphRemarkableMCPIntegration:
         min_similarity = params.get("min_similarity", 0.6)
         max_results = params.get("max_results", 10)
         entity_types = params.get("entity_types")
-        
+
         if not file_path:
             return {"success": False, "error": "file_path is required"}
-        
+
         # Perform semantic search
-        success, result = self.kg_integration_service.semantic_search_from_handwritten_query(
-            rm_file_path=file_path,
-            min_similarity=min_similarity,
-            max_results=max_results,
-            entity_types=entity_types
+        success, result = (
+            self.kg_integration_service.semantic_search_from_handwritten_query(
+                rm_file_path=file_path,
+                min_similarity=min_similarity,
+                max_results=max_results,
+                entity_types=entity_types,
+            )
         )
-        
+
         if not success:
-            return {"success": False, "error": result.get("error", "Semantic search failed")}
-        
+            return {
+                "success": False,
+                "error": result.get("error", "Semantic search failed"),
+            }
+
         return {
             "success": True,
             "query": result.get("query"),
             "results": result.get("search_results", []),
-            "count": result.get("result_count", 0)
+            "count": result.get("result_count", 0),
         }
-    
+
     def augment_notebook_with_knowledge(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """
         Augment a reMarkable notebook with knowledge graph information.
-        
+
         Args:
             params: Dictionary with the following keys:
                 - file_path: Path to the .rm file with handwritten notes (required)
                 - include_related: Whether to include related entities (default: true)
                 - include_semantic: Whether to include semantic entities (default: true)
-                
+
         Returns:
             Result dictionary
         """
         file_path = params.get("file_path")
         include_related = params.get("include_related", True)
         include_semantic = params.get("include_semantic", True)
-        
+
         if not file_path:
             return {"success": False, "error": "file_path is required"}
-        
+
         # Augment notebook with knowledge
         success, result = self.kg_integration_service.augment_notebook_with_knowledge(
             rm_file_path=file_path,
             include_related=include_related,
-            include_semantic=include_semantic
+            include_semantic=include_semantic,
         )
-        
+
         if not success:
-            return {"success": False, "error": result.get("error", "Augmentation failed")}
-        
+            return {
+                "success": False,
+                "error": result.get("error", "Augmentation failed"),
+            }
+
         return {
             "success": True,
             "original_text": result.get("original_text"),
             "entities": result.get("entities", []),
-            "summary": result.get("summary")
+            "summary": result.get("summary"),
         }
 
 
 # MCP tool handler functions (for direct use with MCP server)
+
 
 def extract_knowledge_from_notebook(params):
     """MCP handler for extracting knowledge from a reMarkable notebook."""

--- a/src/inklink/mcp/knowledge_index_tools.py
+++ b/src/inklink/mcp/knowledge_index_tools.py
@@ -18,30 +18,30 @@ logger = logging.getLogger(__name__)
 class KnowledgeIndexMCPIntegration:
     """
     Integration of knowledge index service with MCP tools.
-    
+
     This class provides MCP-compatible functions for creating and managing
     knowledge index notebooks that organize content for easy reference.
     """
-    
+
     def __init__(self, knowledge_index_service: KnowledgeIndexService):
         """
         Initialize the MCP integration.
-        
+
         Args:
             knowledge_index_service: Service for knowledge index functionality
         """
         self.knowledge_index_service = knowledge_index_service
-    
+
     def create_entity_index(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """
         Create an entity index notebook.
-        
+
         Args:
             params: Dictionary with the following keys:
                 - entity_types: Optional list of entity types to include
                 - min_references: Minimum number of references (default: 1)
                 - upload_to_remarkable: Whether to upload to reMarkable (default: true)
-                
+
         Returns:
             Result dictionary
         """
@@ -49,17 +49,17 @@ class KnowledgeIndexMCPIntegration:
         entity_types = params.get("entity_types")
         min_references = params.get("min_references", 1)
         upload_to_remarkable = params.get("upload_to_remarkable", True)
-        
+
         # Create the entity index
         success, result = self.knowledge_index_service.create_entity_index(
             entity_types=entity_types,
             min_references=min_references,
-            upload_to_remarkable=upload_to_remarkable
+            upload_to_remarkable=upload_to_remarkable,
         )
-        
+
         if not success:
             return {"success": False, "error": result.get("error", "Creation failed")}
-        
+
         # Return summarized result
         return {
             "success": True,
@@ -67,19 +67,19 @@ class KnowledgeIndexMCPIntegration:
             "entity_types": result.get("entity_types", []),
             "document_path": result.get("document_path"),
             "uploaded": result.get("upload_result", {}).get("success", False),
-            "title": result.get("upload_result", {}).get("title", "")
+            "title": result.get("upload_result", {}).get("title", ""),
         }
-    
+
     def create_topic_index(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """
         Create a topic index notebook.
-        
+
         Args:
             params: Dictionary with the following keys:
                 - top_n_topics: Number of top topics (default: 20)
                 - min_connections: Minimum connections (default: 2)
                 - upload_to_remarkable: Whether to upload to reMarkable (default: true)
-                
+
         Returns:
             Result dictionary
         """
@@ -87,79 +87,79 @@ class KnowledgeIndexMCPIntegration:
         top_n_topics = params.get("top_n_topics", 20)
         min_connections = params.get("min_connections", 2)
         upload_to_remarkable = params.get("upload_to_remarkable", True)
-        
+
         # Create the topic index
         success, result = self.knowledge_index_service.create_topic_index(
             top_n_topics=top_n_topics,
             min_connections=min_connections,
-            upload_to_remarkable=upload_to_remarkable
+            upload_to_remarkable=upload_to_remarkable,
         )
-        
+
         if not success:
             return {"success": False, "error": result.get("error", "Creation failed")}
-        
+
         # Return summarized result
         return {
             "success": True,
             "topic_count": result.get("topic_count", 0),
             "document_path": result.get("document_path"),
             "uploaded": result.get("upload_result", {}).get("success", False),
-            "title": result.get("upload_result", {}).get("title", "")
+            "title": result.get("upload_result", {}).get("title", ""),
         }
-    
+
     def create_notebook_index(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """
         Create a notebook content index.
-        
+
         Args:
             params: Dictionary with the following keys:
                 - upload_to_remarkable: Whether to upload to reMarkable (default: true)
-                
+
         Returns:
             Result dictionary
         """
         # Get parameters
         upload_to_remarkable = params.get("upload_to_remarkable", True)
-        
+
         # Create the notebook index
         success, result = self.knowledge_index_service.create_notebook_index(
             upload_to_remarkable=upload_to_remarkable
         )
-        
+
         if not success:
             return {"success": False, "error": result.get("error", "Creation failed")}
-        
+
         # Return summarized result
         return {
             "success": True,
             "notebook_count": result.get("notebook_count", 0),
             "document_path": result.get("document_path"),
             "uploaded": result.get("upload_result", {}).get("success", False),
-            "title": result.get("upload_result", {}).get("title", "")
+            "title": result.get("upload_result", {}).get("title", ""),
         }
-    
+
     def create_master_index(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """
         Create a master index notebook containing entity, topic, and notebook indices.
-        
+
         Args:
             params: Dictionary with the following keys:
                 - upload_to_remarkable: Whether to upload to reMarkable (default: true)
-                
+
         Returns:
             Result dictionary
         """
         # Get parameters
         upload_to_remarkable = params.get("upload_to_remarkable", True)
-        
+
         # Create the master index
         success, result = self.knowledge_index_service.create_master_index(
             upload_to_remarkable=upload_to_remarkable
         )
-        
+
         if not success:
             return {"success": False, "error": result.get("error", "Creation failed")}
-        
+
         # Return summarized result
         return {
             "success": True,
@@ -168,11 +168,12 @@ class KnowledgeIndexMCPIntegration:
             "notebook_count": result.get("notebook_count", 0),
             "document_path": result.get("document_path"),
             "uploaded": result.get("upload_result", {}).get("success", False),
-            "title": result.get("upload_result", {}).get("title", "")
+            "title": result.get("upload_result", {}).get("title", ""),
         }
 
 
 # MCP tool handler functions (for direct use with MCP server)
+
 
 def create_entity_index(params):
     """MCP handler for creating an entity index notebook."""


### PR DESCRIPTION
This PR fixes the flake8 linting issues in the MCP integration files that were causing CI failures.

## Changes
- Fixed whitespace in blank lines
- Added newlines at end of files
- Fixed trailing whitespace

These fixes should address the CI failures and allow the PR to be merged.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Resolve code style violations in MCP integration modules to ensure compliance with linting standards and restore CI stability.

Bug Fixes:
- Fix flake8 linting issues in MCP integration files, including whitespace, trailing spaces, and missing newlines.

CI:
- Resolve linting errors to address CI failures.