### PR TITLE
fix: add Poetry installation to Shippie workflow step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install Poetry
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
       - name: Code Review GPT
         uses: mattzcarey/shippie@v0.14.0
 


### PR DESCRIPTION
## Summary

The Shippie code review action was failing with the error `poetry: command not found`. This occurs because:

1. Shippie runs `bun add shippie@latest` during setup
2. This triggers our `postinstall` script in `package.json`
3. The postinstall script runs `poetry install`
4. But Poetry wasn't installed in the code-review workflow job

This PR adds the necessary Poetry installation steps before running Shippie.

## Changes

- Added Python setup step to code-review job
- Added Poetry installation step before running Shippie

## Issue

Fixes the failing Shippie action in PR workflows with error:
```
/usr/bin/bash: line 1: poetry: command not found
error: postinstall script from "inklink" exited with 127
```

## Summary by Sourcery

Add Python and Poetry installation steps to the code-review GitHub Actions job to fix missing Poetry errors when running Shippie

Bug Fixes:
- Fix code-review workflow failure due to missing Poetry command

CI:
- Set up Python 3.10 in the code-review job
- Install Poetry before running Shippie in the code-review workflow